### PR TITLE
Refactor API routes and subscription plan logic

### DIFF
--- a/backend/src/main/java/org/kh/neuralpix/controller/AuthController.java
+++ b/backend/src/main/java/org/kh/neuralpix/controller/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("api/v1/auth")
 @Tag(name = "Authentication", description = "Authentication management APIs")
 public class AuthController {
 

--- a/backend/src/main/java/org/kh/neuralpix/controller/SubscriptionController.java
+++ b/backend/src/main/java/org/kh/neuralpix/controller/SubscriptionController.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/subscriptions")
+@RequestMapping("/api/v1/subscriptions")
 @Slf4j
 public class SubscriptionController {
 

--- a/backend/src/main/java/org/kh/neuralpix/controller/SubscriptionPlanController.java
+++ b/backend/src/main/java/org/kh/neuralpix/controller/SubscriptionPlanController.java
@@ -1,5 +1,7 @@
 package org.kh.neuralpix.controller;
 
+import org.kh.neuralpix.dto.SubscriptionPlanDto;
+import org.kh.neuralpix.dto.request.SubscriptionPlanRequestDto;
 import org.kh.neuralpix.model.SubscriptionPlan;
 import org.kh.neuralpix.service.SubscriptionPlanService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,46 +11,48 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/subscription-plans")
+@RequestMapping("/api/v1/plans")
 public class SubscriptionPlanController {
 
-//    private final SubscriptionPlanService service;
-//
-//    @Autowired
-//    public SubscriptionPlanController(SubscriptionPlanService service) {
-//        this.service = service;
-//    }
-//
-//    @GetMapping
-//    public ResponseEntity<List<SubscriptionPlan>> getAll() {
-//        return ResponseEntity.ok(service.getAll());
-//    }
-//
-//    @GetMapping("/{id}")
-//    public ResponseEntity<SubscriptionPlan> getById(@PathVariable Long id) {
-//        return service.getById(id)
-//                .map(ResponseEntity::ok)
-//                .orElse(ResponseEntity.notFound().build());
-//    }
-//
-//    @GetMapping("/active")
-//    public ResponseEntity<List<SubscriptionPlan>> getActivePlans() {
-//        return ResponseEntity.ok(service.getActivePlans());
-//    }
-//
-//    @PostMapping
-//    public ResponseEntity<SubscriptionPlan> create(@RequestBody SubscriptionPlan plan) {
-//        return ResponseEntity.ok(service.create(plan));
-//    }
-//
-//    @PutMapping("/{id}")
-//    public ResponseEntity<SubscriptionPlan> update(@PathVariable Long id, @RequestBody SubscriptionPlan plan) {
-//        return ResponseEntity.ok(service.update(id, plan));
-//    }
-//
-//    @DeleteMapping("/{id}")
-//    public ResponseEntity<Void> delete(@PathVariable Long id) {
-//        service.delete(id);
-//        return ResponseEntity.noContent().build();
-//    }
+    private final SubscriptionPlanService service;
+
+    @Autowired
+    public SubscriptionPlanController(SubscriptionPlanService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SubscriptionPlan>> getAll() {
+        return ResponseEntity.ok(service.getAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SubscriptionPlan> getById(@PathVariable Long id) {
+        SubscriptionPlan plan = service.getById(id);
+        if (plan != null) {
+            return ResponseEntity.ok(plan);
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<List<SubscriptionPlan>> getActivePlans() {
+        return ResponseEntity.ok(service.getActivePlans());
+    }
+
+    @PostMapping
+    public ResponseEntity<SubscriptionPlan> create(@RequestBody SubscriptionPlanDto plan) {
+        return ResponseEntity.ok(service.create(plan));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SubscriptionPlan> update(@PathVariable Long id, @RequestBody SubscriptionPlanRequestDto plan) {
+        return ResponseEntity.ok(service.update(id, plan));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/org/kh/neuralpix/controller/UsageTrackingController.java
+++ b/backend/src/main/java/org/kh/neuralpix/controller/UsageTrackingController.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 @RestController
-@RequestMapping("/api/usage-tracking")
+@RequestMapping("/api/v1/usage-tracking")
 public class UsageTrackingController {
 
     private final UsageTrackingService service;

--- a/backend/src/main/java/org/kh/neuralpix/model/SubscriptionTier.java
+++ b/backend/src/main/java/org/kh/neuralpix/model/SubscriptionTier.java
@@ -3,5 +3,6 @@ package org.kh.neuralpix.model;
 public enum SubscriptionTier {
     FREE,
     PREMIUM,
-    BASIC
+    BASIC,
+    ENTERPRISE,
 }

--- a/backend/src/main/java/org/kh/neuralpix/repository/SubscriptionPlanRepository.java
+++ b/backend/src/main/java/org/kh/neuralpix/repository/SubscriptionPlanRepository.java
@@ -9,7 +9,8 @@ import java.util.List;
 
 @Repository
 public interface SubscriptionPlanRepository extends JpaRepository<SubscriptionPlan, Long> {
-    List<SubscriptionPlan> findByIsActiveTrue();
+
+    List<SubscriptionPlan> findByIsActive(SubscriptionPlan.IsActive isActive);
     SubscriptionPlan findByTierAndIsActive(SubscriptionTier tier, SubscriptionPlan.IsActive isActive);
     boolean existsByName(String name);
 }

--- a/backend/src/main/java/org/kh/neuralpix/security/SecurityConfig.java
+++ b/backend/src/main/java/org/kh/neuralpix/security/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui.html").permitAll()
                         .requestMatchers("/swagger-resources/**").permitAll()
                         .requestMatchers("/webjars/**").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/backend/src/main/java/org/kh/neuralpix/service/impl/SubscriptionPlanServiceImpl.java
+++ b/backend/src/main/java/org/kh/neuralpix/service/impl/SubscriptionPlanServiceImpl.java
@@ -86,12 +86,12 @@ public class SubscriptionPlanServiceImpl implements SubscriptionPlanService {
             throw new ResourceNotFoundException("SubscriptionPlan", "id", id.toString());
         }
         SubscriptionPlan plan = planRepository.findById(id).get();
-        plan.setIsActive(SubscriptionPlan.IsActive.TRUE);
+        plan.setIsActive(SubscriptionPlan.IsActive.FALSE);
         planRepository.save(plan);
     }
 
     @Override
     public List<SubscriptionPlan> getActivePlans() {
-        return planRepository.findByIsActiveTrue();
+        return planRepository.findByIsActive(SubscriptionPlan.IsActive.TRUE);
     }
 }


### PR DESCRIPTION
Updated API route prefixes to use '/api/v1' for versioning across controllers. Refactored SubscriptionPlanController to use DTOs and restored CRUD endpoints. Modified SubscriptionPlanRepository and service to use IsActive enum for plan status. Added ENTERPRISE tier to SubscriptionTier enum. SecurityConfig now permits all requests by default.